### PR TITLE
[ENH/CLN!] Make gempy a soft optional dependency for the viewer. Refactor GemPy dependencies and update requirements

### DIFF
--- a/gempy_viewer/API/_plot_LiquidEarth.py
+++ b/gempy_viewer/API/_plot_LiquidEarth.py
@@ -1,11 +1,10 @@
 from typing import Optional
 
-import gempy
 from gempy_viewer.optional_dependencies import require_liquid_earth_sdk
 
 
 def plot_to_liquid_earth(
-        geo_model: gempy.data.GeoModel, space_name: str,
+        geo_model: "gempy.data.GeoModel", space_name: str,
         file_name: str = "gempy_model", user_token: Optional[str] = None, grab_link=True,
         make_new_space: bool = False
 ):

--- a/gempy_viewer/DEP/_plot.py
+++ b/gempy_viewer/DEP/_plot.py
@@ -27,7 +27,8 @@
 # sys.path.append( path.dirname( path.dirname( path.abspath(__file__) ) ) )
 
 from typing import Set, Tuple, Dict, Union
-import gempy as _gempy
+
+from gempy_viewer import optional_dependencies
 from gempy_viewer.DEP._visualization_2d import PlotData2D, PlotSolution
 from gempy_viewer.DEP.visualization_3d import GemPyvtkInteract
 
@@ -99,6 +100,7 @@ def export_to_vtk(geo_data, path=None, name=None, voxels=True, block=None, surfa
                                                path=path)
     if surfaces is True:
         geo_data.solutions.compute_all_surfaces()
+        _gempy = optional_dependencies.require_gempy()
         ver, sim = _gempy.get_surfaces(geo_data)
         GemPyvtkInteract.export_vtk_surfaces(geo_data, ver, sim, path=path,
                                              name=name)
@@ -387,39 +389,3 @@ def plot_topology(
         edge_kwargs=edge_kwargs
     )
 
-
-def plot_ar(geo_model, path=None, project_name=None, api_token=None, secret=None):
-    """ Create, upload and retrieve tag to visualize the model in AR in rexview
-
-    https://www.rexos.org/getting-started/
-
-    Args:
-        geo_model (gempy.Model):
-        path: Location for rex files. Default cwd
-        project_name: Name of the project in rexos
-        api_token: rexos api token
-        secret: rexos secret
-
-    Returns:
-        gempy.addons.rex_api.Rextag
-    """
-    from gempy.addons.rex_api import upload_to_rexcloud
-    from gempy.addons.gempy_to_rexfile import write_rex, geomodel_to_rex
-    if project_name is None:
-        project_name = geo_model.meta.project_name
-
-    if path is None:
-        path = '/'
-
-    rex_bytes = geomodel_to_rex(geo_model)
-    files_path = write_rex(rex_bytes, path)
-    project_name_ = project_name
-    for i in range(40):
-        try:
-            tag = upload_to_rexcloud(files_path, project_name=project_name_, api_token=api_token, secret=secret)
-            break
-        except ConnectionError:
-            project_name_ = project_name + str(i)
-            pass
-
-    return tag

--- a/gempy_viewer/DEP/visualization_3d.py
+++ b/gempy_viewer/DEP/visualization_3d.py
@@ -30,9 +30,9 @@ import copy
 import pandas as pn
 import numpy as np
 import sys
-import gempy as gp
 import warnings
 
+from gempy_viewer import optional_dependencies
 
 warnings.filterwarnings("ignore",
                         message='.*Conversion of the second argument of issubdtype *.',
@@ -1116,6 +1116,7 @@ class vtkVisualization(object):
         if delete is True:
             self.delete_surfaces()
         try:
+            gp = optional_dependencies.require_gempy()
             gp.compute_model(self.geo_model, sort_surfaces=False, compute_mesh=True)
         except IndexError:
             print('IndexError: Model not computed. Laking data in some surface')

--- a/gempy_viewer/__init__.py
+++ b/gempy_viewer/__init__.py
@@ -2,13 +2,12 @@ import sys
 
 from gempy_viewer.modules.plot_3d.vista import GemPyToVista
 from .API import *
-import gempy
 __all__ = ['plot_2d', 'plot_3d', 'plot_section_traces', 'plot_topology', 'plot_stereonet']
 
 
 # Assert at least pyton 3.10
 assert sys.version_info[0] >= 3 and sys.version_info[1] >= 10, "GemPy requires Python 3.10 or higher"
-__version__ = gempy.__version__
+from ._version import __version__
 
 if __name__ == '__main__':
     pass

--- a/gempy_viewer/optional_dependencies.py
+++ b/gempy_viewer/optional_dependencies.py
@@ -12,6 +12,13 @@ def require_gempy_plugins():
         raise ImportError("The gempy.plugins package is required to run this function.")
     return gempy.plugins
 
+def require_gempy():
+    try:
+        import gempy
+    except ImportError:
+        raise ImportError("The gempy package is required to run this function.")
+    return gempy
+
 
 def require_pyvista():
     try:

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,3 +1,4 @@
--r optional_requirements.txt
+-r requirements.txt
 
 pytest
+gempy

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,2 @@
-gempy~=2024.2.0
 matplotlib
 numpy


### PR DESCRIPTION
Replaces direct imports of GemPy with a dynamic import through `optional_dependencies`. Cleans up unused code, updates version handling, and adjusts requirements files. This improves modularity and simplifies dependency management.