### PR TITLE
[ENH] Add camera position kwargs and fix scalar bar annotations in 3D plotting

### DIFF
--- a/gempy_viewer/API/_plot_3d_API.py
+++ b/gempy_viewer/API/_plot_3d_API.py
@@ -223,7 +223,7 @@ def plot_3d(
         set_scalar_bar(
             gempy_vista=gempy_vista,
             elements_names=structural_frame.elements_names,
-            surfaces_ids=structural_frame.elements_ids - 1,
+            surfaces_ids=structural_frame.elements_enumerator,
             custom_colors=structural_frame.elements_colors_volumes
         )
 

--- a/gempy_viewer/API/_plot_3d_API.py
+++ b/gempy_viewer/API/_plot_3d_API.py
@@ -34,6 +34,7 @@ def plot_3d(
         ve: Optional[float] = None,
         topography_scalar_type: TopographyDataType = TopographyDataType.GEOMAP,
         kwargs_pyvista_bounds: Optional[dict] = None,
+        kwargs_pyvista_camera: Optional[dict] = None,
         kwargs_plot_structured_grid: Optional[dict] = None,
         kwargs_plot_topography: Optional[dict] = None,
         kwargs_plot_data: Optional[dict] = None,
@@ -115,6 +116,7 @@ def plot_3d(
     kwargs_plotter = kwargs_plotter or {}
     kwargs_plot_surfaces = kwargs_plot_surfaces or {}
     kwargs_pyvista_bounds = kwargs_pyvista_bounds or {}
+    kwargs_pyvista_camera = kwargs_pyvista_camera or {}
 
     if image is True:
         show = True
@@ -133,6 +135,7 @@ def plot_3d(
         extent=extent,
         plotter_type=plotter_type,
         pyvista_bounds_kwargs=kwargs_pyvista_bounds,
+        pyvista_camera_kwargs=kwargs_pyvista_camera,
         **kwargs_plotter
     )
 

--- a/gempy_viewer/modules/plot_3d/plot_3d_utils.py
+++ b/gempy_viewer/modules/plot_3d/plot_3d_utils.py
@@ -52,18 +52,17 @@ def set_scalar_bar(gempy_vista: GemPyToVista, elements_names: list[str],
     # Get the lookup table from the mapper
     lut = mapper_actor.mapper.lookup_table
 
-    # Create annotations mapping integers to element names
+    # Create annotations mapping surface IDs to element names
     annotations = {}
-    for e, name in enumerate(elements_names[::-1]):
-        # Convert integer to string for the annotation key
-        annotations[str(e)] = name
+    for surface_id, name in zip(surfaces_ids, elements_names[::-1]):
+        annotations[str(surface_id)] = name
 
     # Apply annotations to the lookup table
     lut.annotations = annotations
 
     # Set number of colors to match the number of categories
     n_colors = len(elements_names)
-    lut.n_values = n_colors - 1
+    lut.n_values = n_colors
 
     # Apply custom colors if provided
     if custom_colors is not None:

--- a/gempy_viewer/modules/plot_3d/plot_octree_gizmos.py
+++ b/gempy_viewer/modules/plot_3d/plot_octree_gizmos.py
@@ -14,7 +14,7 @@ def plot_octree_gizmos(model: GeoModel, pd3: GemPyToVista):
         # Map the current level (i) to a 0.0 - 1.0 range for the colormap
         level_color = cmap(i / max(1, n_levels - 1))[:3]
 
-        corners_grid = octree_level.grid_centers.corners_grid
+        corners_grid = octree_level.grid.corners_grid
         if corners_grid is None:
             continue
         _plot_octree_gizmos(

--- a/gempy_viewer/modules/plot_3d/vista.py
+++ b/gempy_viewer/modules/plot_3d/vista.py
@@ -45,11 +45,10 @@ except ImportError:
 from gempy_viewer.optional_dependencies import require_pyvista
 
 
-
 class GemPyToVista:
 
     def __init__(self, extent: Union[np.ndarray | list[float]], plotter_type: str = 'basic',
-                 live_updating=False, pyvista_bounds_kwargs: Optional[dict] = None, **kwargs):
+                 live_updating=False, pyvista_bounds_kwargs: Optional[dict] = None, pyvista_camera_kwargs: Optional[dict] = None, **kwargs):
         """GemPy 3-D visualization using pyVista.
 
         Args:
@@ -65,7 +64,7 @@ class GemPyToVista:
         """
 
         pv = require_pyvista()
-        
+
         if pyvista_bounds_kwargs is None:
             pyvista_bounds_kwargs = {}
 
@@ -92,7 +91,10 @@ class GemPyToVista:
 
         # Default camera and bounds
         self.set_bounds(extent, **pyvista_bounds_kwargs)
-        self.p.view_isometric(negative=False)
+        camera_position = pyvista_camera_kwargs.get('position', None)
+        if camera_position is not None:
+            self.p.camera_position = camera_position
+        
 
         # Actors containers
         self.surface_actors = {}

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,8 +1,7 @@
 -r optional_requirements.txt
 
 pytest
-gempy
 imagehash
 pillow
 pydantic
-gempy>=2025.2.0dev0,<2025.3.0
+gempy>=2025.2.0dev0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,11 @@ def one_fault_model_topo_solution() -> GeoModel:
         topography_resolution=np.array([60, 60])
     )
     
-    gp.compute_model(one_fault_model, gp.data.GemPyEngineConfig(backend=gp.data.AvailableBackends.numpy))
+    gp.compute_model(
+        one_fault_model,
+        gp.data.GemPyEngineConfig(backend=gp.data.AvailableBackends.numpy),
+        validate_serialization=True
+    )
     return one_fault_model
 
 

--- a/tests/test_plotting/test_plot_2d.py
+++ b/tests/test_plotting/test_plot_2d.py
@@ -159,7 +159,10 @@ class TestPlot2DSolutionsOctrees:
     @pytest.fixture(scope='class')
     def one_fault_model_topo_solution_octrees(self) -> gp.data.GeoModel:
         one_fault_model = _one_fault_model_generator()
-        one_fault_model.grid.regular_grid.resolution = [2, 4, 2]
+        one_fault_model.grid.regular_grid.set_regular_grid(
+            extent=one_fault_model.grid.regular_grid.extent,
+            resolution=np.array([2, 4, 2])
+        )
 
         one_fault_model.interpolation_options.number_octree_levels = 5
 

--- a/tests/test_plotting/test_plot_3d.py
+++ b/tests/test_plotting/test_plot_3d.py
@@ -36,7 +36,7 @@ class TestPlot3DSolutions:
 
         check_image_hash(
             plot3d=plot3d,
-            hash='07040030001'
+            hash='07040030000'
         )
 
     def test_plot_3d_solutions_volume_and_input(self, one_fault_model_topo_solution):
@@ -55,7 +55,7 @@ class TestPlot3DSolutions:
 
         check_image_hash(
             plot3d=plot3d,
-            hash='07400018000'
+            hash='07040250000'
         )
 
     def test_plot_3d_solutions_only_volume(self, one_fault_model_topo_solution):
@@ -72,7 +72,7 @@ class TestPlot3DSolutions:
 
         check_image_hash(
             plot3d=plot3d,
-            hash='07c00000000'
+            hash='074400c0000'
         )
 
     def test_plot_3d_solutions_only_input(self, one_fault_model_topo_solution):
@@ -89,7 +89,7 @@ class TestPlot3DSolutions:
 
         check_image_hash(
             plot3d=plot3d,
-            hash='06000038040'
+            hash='06000030080'
         )
 
     def test_plot_3d_scalar_field(self, one_fault_model_topo_solution):
@@ -104,7 +104,7 @@ class TestPlot3DSolutions:
 
         check_image_hash(
             plot3d=plot3d,
-            hash='07600210000'
+            hash='06600210001'
         )
 
     def test_plot_3d_solutions_topography(self, one_fault_model_topo_solution):
@@ -131,7 +131,7 @@ class TestPlot3DSolutions:
 
         check_image_hash(
             plot3d=plot3d,
-            hash='07040030001'
+            hash='07040030000'
         )
 
 

--- a/tests/test_plotting/test_plot_3d.py
+++ b/tests/test_plotting/test_plot_3d.py
@@ -139,7 +139,10 @@ class TestPlot2DSolutionsOctrees:
     @pytest.fixture(scope='class')
     def one_fault_model_topo_solution_octrees(self) -> GeoModel:
         one_fault_model = _one_fault_model_generator()
-        one_fault_model.grid.regular_grid.resolution = np.array([2, 4, 2])
+        one_fault_model.grid.regular_grid.set_regular_grid(
+            extent=one_fault_model.grid.regular_grid.extent,
+            resolution=np.array([2, 4, 2])
+        )
 
         one_fault_model.interpolation_options.number_octree_levels = 5
 

--- a/tests/test_private/test_terranigma/test_3d_colormaps.py
+++ b/tests/test_private/test_terranigma/test_3d_colormaps.py
@@ -48,7 +48,7 @@ class Test3DColormaps:
 
         check_image_hash(
             plot3d=plot3d,
-            hash='07000019000'
+            hash='07000018001'
         )
 
     def test_3d_volume_vol(self, computed_model):


### PR DESCRIPTION
[BUG] Fix `corners_grid` attribute reference in octree gizmo plotting

[ENH] Add `kwargs_pyvista_camera` for customizing 3D camera settings

Introduce `kwargs_pyvista_camera` in `_plot_3d_API` and `GemPyToVista` classes to support flexible 3D camera customization, including setting camera position.

[BUG] Fix regular grid initialization in 2D and 3D test fixtures

Replace direct resolution assignment with `set_regular_grid` for consistent grid initialization in test cases.

[BUG] Update image hash values and fix surface ID mapping in 3D plotting

Correct image hash values in test cases for `plot_3d` and fix surface ID annotations in `plot_3d_utils`. Update backend configuration in `conftest.py` to include serialization validation. Adjust scalar bar `surfaces_ids` handling in `_plot_3d_API`.